### PR TITLE
Allow CompactAxis in check_axis

### DIFF
--- a/src/covjson_pydantic/domain.py
+++ b/src/covjson_pydantic/domain.py
@@ -122,8 +122,8 @@ class Domain(CovJsonBaseModel, extra="allow"):
                     )
                 if isinstance(axis, CompactAxis) and axis.num != 1:
                     raise ValueError(
-                        f"If provided, the 'values' field of the CompactAxis '{axis_name}'-axis "
-                        f"of a '{domain_type.value}' domain must contain a single value."
+                        f"If provided, the 'num' field of the CompactAxis '{axis_name}'-axis "
+                        f"of a '{domain_type.value}' domain must be 1."
                     )
 
     @model_validator(mode="after")

--- a/src/covjson_pydantic/domain.py
+++ b/src/covjson_pydantic/domain.py
@@ -93,10 +93,19 @@ class Domain(CovJsonBaseModel, extra="allow"):
             if axis is None:
                 raise ValueError(f"A '{domain_type.value}' must have a '{axis_name}'-axis.")
             if axis_name in single_value_axes:
-                if not (isinstance(axis, ValuesAxis, CompactAxis) and len(axis.values) == 1):
+                if isinstance(axis, ValuesAxis) and len(axis.values) != 1:
                     raise ValueError(
-                        f"The 'values' field of the '{axis_name}'-axis "
+                        f"The 'values' field of the ValuesAxis '{axis_name}'-axis "
                         f"of a '{domain_type.value}' domain must contain a single value."
+                    )
+                if isinstance(axis, CompactAxis) and axis.num != 1:
+                    raise ValueError(
+                        f"The 'values' field of the CompactAxis '{axis_name}'-axis "
+                        f"of a '{domain_type.value}' domain must contain a single value."
+                    )
+                if not (isinstance(axis, ValuesAxis) or isinstance(axis, CompactAxis)):
+                    raise ValueError(
+                        f"The '{axis_name}'-axis should be of type CompactAxis or ValueAxis."
                     )
 
         # Check allowed axes

--- a/src/covjson_pydantic/domain.py
+++ b/src/covjson_pydantic/domain.py
@@ -100,8 +100,8 @@ class Domain(CovJsonBaseModel, extra="allow"):
                     )
                 if isinstance(axis, CompactAxis) and axis.num != 1:
                     raise ValueError(
-                        f"The 'values' field of the CompactAxis '{axis_name}'-axis "
-                        f"of a '{axis.num}' domain must contain a single value."
+                        f"The 'num' field of the CompactAxis '{axis_name}'-axis "
+                        f"of a '{domain_type.value}' domain must contain a single value."
                     )
 
         # Check allowed axes
@@ -115,9 +115,14 @@ class Domain(CovJsonBaseModel, extra="allow"):
         for axis_name in allowed_axes:
             axis = getattr(axes, axis_name)
             if axis is not None and axis_name in single_value_axes:
-                if not (isinstance(axis, ValuesAxis) and len(axis.values) == 1):
+                if isinstance(axis, ValuesAxis) and len(axis.values) != 1:
                     raise ValueError(
-                        f"If provided, the 'values' field of the '{axis_name}'-axis "
+                        f"If provided, the 'values' field of the ValuesAxis '{axis_name}'-axis "
+                        f"of a '{domain_type.value}' domain must contain a single value."
+                    )
+                if isinstance(axis, CompactAxis) and axis.num != 1:
+                    raise ValueError(
+                        f"If provided, the 'values' field of the CompactAxis '{axis_name}'-axis "
                         f"of a '{domain_type.value}' domain must contain a single value."
                     )
 

--- a/src/covjson_pydantic/domain.py
+++ b/src/covjson_pydantic/domain.py
@@ -93,7 +93,7 @@ class Domain(CovJsonBaseModel, extra="allow"):
             if axis is None:
                 raise ValueError(f"A '{domain_type.value}' must have a '{axis_name}'-axis.")
             if axis_name in single_value_axes:
-                if not (isinstance(axis, ValuesAxis) and len(axis.values) == 1):
+                if not (isinstance(axis, ValuesAxis, CompactAxis) and len(axis.values) == 1):
                     raise ValueError(
                         f"The 'values' field of the '{axis_name}'-axis "
                         f"of a '{domain_type.value}' domain must contain a single value."

--- a/src/covjson_pydantic/domain.py
+++ b/src/covjson_pydantic/domain.py
@@ -101,7 +101,7 @@ class Domain(CovJsonBaseModel, extra="allow"):
                 if isinstance(axis, CompactAxis) and axis.num != 1:
                     raise ValueError(
                         f"The 'num' field of the CompactAxis '{axis_name}'-axis "
-                        f"of a '{domain_type.value}' domain must contain a single value."
+                        f"of a '{domain_type.value}' domain must be 1."
                     )
 
         # Check allowed axes

--- a/src/covjson_pydantic/domain.py
+++ b/src/covjson_pydantic/domain.py
@@ -101,11 +101,7 @@ class Domain(CovJsonBaseModel, extra="allow"):
                 if isinstance(axis, CompactAxis) and axis.num != 1:
                     raise ValueError(
                         f"The 'values' field of the CompactAxis '{axis_name}'-axis "
-                        f"of a '{domain_type.value}' domain must contain a single value."
-                    )
-                if not (isinstance(axis, ValuesAxis) or isinstance(axis, CompactAxis)):
-                    raise ValueError(
-                        f"The '{axis_name}'-axis should be of type CompactAxis or ValueAxis."
+                        f"of a '{axis.num}' domain must contain a single value."
                     )
 
         # Check allowed axes

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -56,7 +56,7 @@ error_cases = [
     (
         "point-series-domain-more-z.json",
         Domain,
-        r"If provided, the 'values' field of the 'z'-axis of a 'PointSeries' domain must contain a single value.",
+        r"If provided, the 'values' field of the ValuesAxis 'z'-axis of a 'PointSeries' domain must contain a single value.",
     ),
     ("point-series-domain-no-t.json", Domain, r"A 'PointSeries' must have a 't'-axis."),
 ]

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -56,8 +56,8 @@ error_cases = [
     (
         "point-series-domain-more-z.json",
         Domain,
-        r"If provided, the 'values' field of the ValuesAxis 'z'-axis of a 'PointSeries' " + \
-            "domain must contain a single value.",
+        r"If provided, the 'values' field of the ValuesAxis 'z'-axis of a 'PointSeries' "
+        + "domain must contain a single value.",
     ),
     ("point-series-domain-no-t.json", Domain, r"A 'PointSeries' must have a 't'-axis."),
 ]

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -26,6 +26,7 @@ happy_cases = [
     ("spec-domain-vertical-profile.json", Domain),
     ("spec-domain-point-series.json", Domain),
     ("spec-domain-point.json", Domain),
+    ("spec-domain-point-compact.json", Domain),
     ("spec-domain-multipoint-series.json", Domain),
     ("spec-domain-multipoint.json", Domain),
     ("ndarray-float.json", NdArray),

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -56,7 +56,8 @@ error_cases = [
     (
         "point-series-domain-more-z.json",
         Domain,
-        r"If provided, the 'values' field of the ValuesAxis 'z'-axis of a 'PointSeries' domain must contain a single value.",
+        r"If provided, the 'values' field of the ValuesAxis 'z'-axis of a 'PointSeries' " + \
+            "domain must contain a single value.",
     ),
     ("point-series-domain-no-t.json", Domain, r"A 'PointSeries' must have a 't'-axis."),
 ]

--- a/tests/test_data/spec-domain-point-compact.json
+++ b/tests/test_data/spec-domain-point-compact.json
@@ -1,0 +1,26 @@
+{
+    "type": "Domain",
+    "domainType": "Point",
+    "axes": {
+        "x": {
+            "start": 1.0,
+            "stop": 1.0,
+            "num": 1
+        },
+        "y": {
+            "start": 20.0,
+            "stop": 20.0,
+            "num": 1
+        },
+        "z": {
+            "start": 1.8,
+            "stop": 1.8,
+            "num": 1
+        },
+        "t": {
+            "values": [
+                "2008-01-01T04:00:00Z"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
As far as I understand https://docs.ogc.org/cs/21-069r2/21-069r2.html#_d5c16418-1a20-4dbf-bf7a-8e685062df97 both ValueAxis and CompactAxis should be allowed. The function check_axis currently only allow one of them. This pull request expands to allow both.