### PR TITLE
Add CoverageJSON TypeAdapter to support generic loading of CoverageJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ pip install git+https://github.com/KNMI/covjson-pydantic.git
 
 ## Usage
 
+### Generating CovJSON
+
 ```python
 from datetime import datetime, timezone
 from pydantic import AwareDatetime
@@ -102,6 +104,36 @@ Will print
         }
     }
 }
+```
+
+### Validating CovJSON
+
+There is a helper `TypeAdapter` called `CoverageJSON` that will validate any (supported) CoverageJSON input, and
+return the corresponding model. These can be of the type `CoverageCollection`, `Coverage`, `Domain`, `TiledNdArray`
+or `NdArray`.
+
+```python
+from covjson_pydantic.coverage import CoverageJSON
+covjson = CoverageJSON.validate_json("""
+{
+    "type": "NdArray",
+    "dataType": "float",
+    "axisNames": [
+        "t",
+        "y",
+        "x"
+    ],
+    "shape": [
+        1,
+        1,
+        1
+    ],
+    "values": [
+        27.1
+    ]
+}
+""")
+print(type(covjson))
 ```
 
 ## Contributing

--- a/example.py
+++ b/example.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from datetime import timezone
 
 from covjson_pydantic.coverage import Coverage
+from covjson_pydantic.coverage import CoverageJSON
 from covjson_pydantic.domain import Axes
 from covjson_pydantic.domain import Domain
 from covjson_pydantic.domain import DomainType
@@ -22,3 +23,26 @@ c = Coverage(
 )
 
 print(c.model_dump_json(exclude_none=True, indent=4))
+
+covjson = CoverageJSON.validate_json(
+    """
+{
+    "type": "NdArray",
+    "dataType": "float",
+    "axisNames": [
+        "t",
+        "y",
+        "x"
+    ],
+    "shape": [
+        1,
+        1,
+        1
+    ],
+    "values": [
+        27.1
+    ]
+}
+"""
+)
+print(type(covjson))

--- a/src/covjson_pydantic/coverage.py
+++ b/src/covjson_pydantic/coverage.py
@@ -1,16 +1,19 @@
+from typing import Annotated
 from typing import Dict
 from typing import List
 from typing import Literal
 from typing import Optional
 from typing import Union
 
+from covjson_pydantic.domain import Domain
+from covjson_pydantic.ndarray import NdArray
+from covjson_pydantic.ndarray import TiledNdArray
 from pydantic import AnyUrl
+from pydantic import Field
+from pydantic import TypeAdapter
 
 from .base_models import CovJsonBaseModel
-from .domain import Domain
 from .domain import DomainType
-from .ndarray import NdArray
-from .ndarray import TiledNdArray
 from .parameter import Parameter
 from .parameter import ParameterGroup
 from .reference_system import ReferenceSystemConnectionObject
@@ -32,3 +35,11 @@ class CoverageCollection(CovJsonBaseModel, extra="allow"):
     parameters: Optional[Dict[str, Parameter]] = None
     parameterGroups: Optional[List[ParameterGroup]] = None  # noqa: N815
     referencing: Optional[List[ReferenceSystemConnectionObject]] = None
+
+
+CoverageJSON = TypeAdapter(
+    Annotated[
+        Union[CoverageCollection, Coverage, Domain, TiledNdArray, NdArray],
+        Field(discriminator="type"),
+    ]
+)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from covjson_pydantic.coverage import Coverage
 from covjson_pydantic.coverage import CoverageCollection
+from covjson_pydantic.coverage import CoverageJSON
 from covjson_pydantic.domain import Axes
 from covjson_pydantic.domain import Domain
 from covjson_pydantic.ndarray import NdArray
@@ -76,3 +77,12 @@ def test_error_cases(file_name, object_type, error_message):
 
     with pytest.raises(ValidationError, match=error_message):
         object_type.model_validate_json(json_string)
+
+
+def test_covjson_type_adapter():
+    file = Path(__file__).parent.resolve() / "test_data" / "coverage-json.json"
+    # Put JSON in default unindented format
+    with open(file, "r") as f:
+        o = CoverageJSON.validate_json(f.read())
+
+    assert isinstance(o, Coverage)


### PR DESCRIPTION
This add support for a generic CoverageJSON type which you can use to validate any JSON against. It implements the root types that can form a CoverageJSON, as [defined in the spec](https://docs.ogc.org/cs/21-069r2/21-069r2.html#_b820d882-9fc1-40a5-b6f7-14802e729e5b). 

I've considered (and also tested) the implementation for this as listed in this detailed [SO answer](https://stackoverflow.com/a/76538571/2032745). In the end I've chosen for Option A.

Option B (Custom Root Type): Very noisy implementation, and forgetting your dealing with a proxy object. It's also not easy to use for validation purposes.

Option C (Union field + proxy constructor): The fake class (as function) is not very clean. It's also not easy use for validation.

For the (lightweight) purpose of validation, Option A seems to be the cleanest to use.

