### PR TITLE
Add integer and string support for NdArray values

### DIFF
--- a/src/covjson_pydantic/ndarray.py
+++ b/src/covjson_pydantic/ndarray.py
@@ -18,6 +18,7 @@ class DataType(str, Enum):
 
 class NdArray(CovJsonBaseModel, extra="allow"):
     type: Literal["NdArray"] = "NdArray"
+    # TODO: automatically set type based on `values` data.
     dataType: DataType = DataType.float  # noqa: N815
     axisNames: Optional[List[str]] = None  # noqa: N815
     shape: Optional[List[int]] = None

--- a/src/covjson_pydantic/ndarray.py
+++ b/src/covjson_pydantic/ndarray.py
@@ -1,8 +1,10 @@
 import math
 from enum import Enum
+from typing import Generic
 from typing import List
 from typing import Literal
 from typing import Optional
+from typing import TypeVar
 
 from pydantic import model_validator
 
@@ -15,12 +17,15 @@ class DataType(str, Enum):
     string = "string"
 
 
-class NdArray(CovJsonBaseModel, extra="allow"):
+DataTypeT = TypeVar("DataTypeT")
+
+
+class NdArray(CovJsonBaseModel, Generic[DataTypeT], extra="allow"):
     type: Literal["NdArray"] = "NdArray"
     dataType: DataType = DataType.float  # noqa: N815
     axisNames: Optional[List[str]] = None  # noqa: N815
     shape: Optional[List[int]] = None
-    values: List[Optional[float | int | str]]
+    values: List[Optional[DataTypeT]] = [None]
 
     @model_validator(mode="after")
     def check_field_dependencies(self):

--- a/src/covjson_pydantic/ndarray.py
+++ b/src/covjson_pydantic/ndarray.py
@@ -9,9 +9,10 @@ from pydantic import model_validator
 from .base_models import CovJsonBaseModel
 
 
-# TODO: Support for integers and strings
 class DataType(str, Enum):
     float = "float"
+    integer = "integer"
+    string = "string"
 
 
 class NdArray(CovJsonBaseModel, extra="allow"):
@@ -19,7 +20,7 @@ class NdArray(CovJsonBaseModel, extra="allow"):
     dataType: DataType = DataType.float  # noqa: N815
     axisNames: Optional[List[str]] = None  # noqa: N815
     shape: Optional[List[int]] = None
-    values: List[Optional[float]]
+    values: List[Optional[float | int | str]]
 
     @model_validator(mode="after")
     def check_field_dependencies(self):

--- a/src/covjson_pydantic/ndarray.py
+++ b/src/covjson_pydantic/ndarray.py
@@ -1,10 +1,9 @@
 import math
 from enum import Enum
-from typing import Generic
 from typing import List
 from typing import Literal
 from typing import Optional
-from typing import TypeVar
+from typing import Union
 
 from pydantic import model_validator
 
@@ -17,15 +16,12 @@ class DataType(str, Enum):
     string = "string"
 
 
-DataTypeT = TypeVar("DataTypeT")
-
-
-class NdArray(CovJsonBaseModel, Generic[DataTypeT], extra="allow"):
+class NdArray(CovJsonBaseModel, extra="allow"):
     type: Literal["NdArray"] = "NdArray"
     dataType: DataType = DataType.float  # noqa: N815
     axisNames: Optional[List[str]] = None  # noqa: N815
     shape: Optional[List[int]] = None
-    values: List[Optional[DataTypeT]] = [None]
+    values: Union[List[Optional[float]], List[Optional[str]], List[Optional[int]]]
 
     @model_validator(mode="after")
     def check_field_dependencies(self):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -76,6 +76,7 @@ error_cases = [
     ("point-series-domain-no-t.json", Domain, r"A 'PointSeries' must have a 't'-axis."),
     ("mixed-type-axes.json", Axes, r"Input should be a valid number"),
     ("mixed-type-axes-2.json", Axes, r"Input should be a valid string"),
+    ("mixed-type-ndarray.json", NdArray, r"Input should be a valid number"),
 ]
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -6,12 +6,21 @@ from covjson_pydantic.coverage import Coverage
 from covjson_pydantic.coverage import CoverageCollection
 from covjson_pydantic.domain import Axes
 from covjson_pydantic.domain import Domain
+from covjson_pydantic.ndarray import DataType
 from covjson_pydantic.ndarray import NdArray
 from covjson_pydantic.ndarray import TiledNdArray
 from covjson_pydantic.parameter import Parameter
 from covjson_pydantic.parameter import ParameterGroup
 from covjson_pydantic.reference_system import ReferenceSystem
 from pydantic import ValidationError
+
+
+class NdArrayInteger(NdArray):
+    dataType: DataType = DataType.integer  # noqa: N815
+
+
+class NdArrayString(NdArray):
+    dataType: DataType = DataType.string  # noqa: N815
 
 
 happy_cases = [
@@ -33,6 +42,8 @@ happy_cases = [
     ("spec-domain-multipoint.json", Domain),
     ("spec-domain-trajectory.json", Domain),
     ("ndarray-float.json", NdArray),
+    ("ndarray-integer.json", NdArrayInteger),
+    ("ndarray-string.json", NdArrayString),
     ("spec-ndarray.json", NdArray),
     ("spec-tiled-ndarray.json", TiledNdArray),
     ("continuous-data-parameter.json", Parameter),

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -77,6 +77,7 @@ error_cases = [
     ("mixed-type-axes.json", Axes, r"Input should be a valid number"),
     ("mixed-type-axes-2.json", Axes, r"Input should be a valid string"),
     ("mixed-type-ndarray.json", NdArray, r"Input should be a valid number"),
+    ("mixed-type-ndarray-2.json", NdArray, r"Input should be a valid number"),
 ]
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -6,21 +6,12 @@ from covjson_pydantic.coverage import Coverage
 from covjson_pydantic.coverage import CoverageCollection
 from covjson_pydantic.domain import Axes
 from covjson_pydantic.domain import Domain
-from covjson_pydantic.ndarray import DataType
 from covjson_pydantic.ndarray import NdArray
 from covjson_pydantic.ndarray import TiledNdArray
 from covjson_pydantic.parameter import Parameter
 from covjson_pydantic.parameter import ParameterGroup
 from covjson_pydantic.reference_system import ReferenceSystem
 from pydantic import ValidationError
-
-
-class NdArrayInteger(NdArray):
-    dataType: DataType = DataType.integer  # noqa: N815
-
-
-class NdArrayString(NdArray):
-    dataType: DataType = DataType.string  # noqa: N815
 
 
 happy_cases = [
@@ -42,8 +33,8 @@ happy_cases = [
     ("spec-domain-multipoint.json", Domain),
     ("spec-domain-trajectory.json", Domain),
     ("ndarray-float.json", NdArray),
-    ("ndarray-integer.json", NdArrayInteger),
-    ("ndarray-string.json", NdArrayString),
+    ("ndarray-integer.json", NdArray),
+    ("ndarray-string.json", NdArray),
     ("spec-ndarray.json", NdArray),
     ("spec-tiled-ndarray.json", TiledNdArray),
     ("continuous-data-parameter.json", Parameter),

--- a/tests/test_data/mixed-type-ndarray-2.json
+++ b/tests/test_data/mixed-type-ndarray-2.json
@@ -1,0 +1,16 @@
+{
+    "type": "NdArray",
+    "dataType": "string",
+    "axisNames": [
+        "y",
+        "x"
+    ],
+    "shape": [
+        2
+    ],
+    "values": [
+        123,
+        2.32,
+        "s"
+    ]
+}

--- a/tests/test_data/mixed-type-ndarray.json
+++ b/tests/test_data/mixed-type-ndarray.json
@@ -1,0 +1,15 @@
+{
+    "type": "NdArray",
+    "dataType": "float",
+    "axisNames": [
+        "y",
+        "x"
+    ],
+    "shape": [
+        2
+    ],
+    "values": [
+        "abc",
+        123
+    ]
+}

--- a/tests/test_data/ndarray-integer.json
+++ b/tests/test_data/ndarray-integer.json
@@ -1,0 +1,22 @@
+{
+    "type": "NdArray",
+    "dataType": "string",
+    "axisNames": [
+        "t",
+        "y",
+        "x"
+    ],
+    "shape": [
+        1,
+        2,
+        3
+    ],
+    "values": [
+        3,
+        1,
+        null,
+        3,
+        3,
+        7
+    ]
+}

--- a/tests/test_data/ndarray-string.json
+++ b/tests/test_data/ndarray-string.json
@@ -1,0 +1,22 @@
+{
+    "type": "NdArray",
+    "dataType": "string",
+    "axisNames": [
+        "t",
+        "y",
+        "x"
+    ],
+    "shape": [
+        1,
+        2,
+        3
+    ],
+    "values": [
+        "ABC",
+        "DEF",
+        null,
+        "XYZ",
+        "a123",
+        "qwerty"
+    ]
+}


### PR DESCRIPTION
Adds support for integer and string data types in NdArray values, aligning with the [OGC CoverageJSON spec](https://docs.ogc.org/cs/21-069r2/21-069r2.html#_0c82b6df-30f7-4d54-b90f-a0f98e75deed).

Added relevant tests for integer and string case.